### PR TITLE
fix: close the h2 tag

### DIFF
--- a/iac/web/install_apache.sh.tpl
+++ b/iac/web/install_apache.sh.tpl
@@ -6,4 +6,4 @@ sudo apt-get update
 sudo apt-get install -y apache2
 apachectl start
 sleep 1
-echo '<h2>This is the ${environment} environment <h2>' > /var/www/html/index.html
+echo '<h2>This is the ${environment} environment </h2>' > /var/www/html/index.html


### PR DESCRIPTION
In the install apache file, there is 2 `<h2>` but no `</h2>`, this is solved.